### PR TITLE
fix(webpack.config): reveal process.env.NODE_ENV to node modules

### DIFF
--- a/other/webpack.config.es6.js
+++ b/other/webpack.config.es6.js
@@ -104,7 +104,10 @@ const config = {
     new webpack.DefinePlugin({
       ON_DEV: ON_DEV,
       ON_TEST: ON_TEST,
-      ON_PROD: ON_PROD
+      ON_PROD: ON_PROD,
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }
     })
   ],
 


### PR DESCRIPTION
because redux needs the node-env to adjust what content it gives us as a module process.env.NODE_ENV
is now exposed. If NODE_ENV is undefined, the process will continue as normal. This squelches a
message we were seeing in the console from redux