### PR TITLE
DAS-4335: fix(switcher): add template with viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width = device-width, initial-scale=1.0, user-scalable=no">
+    <title>{%= o.htmlWebpackPlugin.options.title %}</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/other/webpack.config.es6.js
+++ b/other/webpack.config.es6.js
@@ -262,6 +262,7 @@ if (INCLUDE_MULTIPLE_VIEWS) {
         title: 'Switcher',
         dev: ON_DEV,
         pkg: pkg,
+        inject: 'body',
         template: 'index.html',
         chunks: ['switcher']
       }),

--- a/other/webpack.config.es6.js
+++ b/other/webpack.config.es6.js
@@ -262,6 +262,7 @@ if (INCLUDE_MULTIPLE_VIEWS) {
         title: 'Switcher',
         dev: ON_DEV,
         pkg: pkg,
+        template: 'index.html',
         chunks: ['switcher']
       }),
       new HtmlWebpackPlugin({


### PR DESCRIPTION
include template for switcher's index.html to include a viewport meta tag. The viewport meta tag is

needed for enquire.js to properly work and switch to the correct project