### PR TITLE
fix(package.json): fix `cp -r` command to work properly on linux environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tdd": "NODE_ENV=test karma start ./karma.conf.js --browsers Chrome",
     "lint": "eslint src/**",
     "coveralls": "npm run test-ci && node node_modules/lcov-filter/index.js ./coverage/phantomjs/lcov.info spec | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "build": "rm -rf ./dist && NODE_ENV=production ./node_modules/.bin/webpack && cp -r domo/ dist/",
+    "build": "rm -rf ./dist && NODE_ENV=production ./node_modules/.bin/webpack && cp -r domo/* dist/",
     "preversion": "npm run test-ci",
     "version": "npm run build && npm run changelog && git add -A CHANGELOG.md",
     "postversion": "git push && git push --tags",


### PR DESCRIPTION
This addresses #60 

the `cp -r` command worked inconsistently between osx and linux. cp -r on osx will copy the contents
of the first argument (the source directory) into the output directory. On linux, cp -r would copy
the *source folder* into the destination folder. A blob is used to copy all (except dotfiles) from
the domo folder to the dist folder

@sldavidson @andrewjensen 